### PR TITLE
website link in readme

### DIFF
--- a/WEEK_4/wsk-25-react/README.md
+++ b/WEEK_4/wsk-25-react/README.md
@@ -1,3 +1,5 @@
+[WEBSITE DEMO](https://users.metropolia.fi/~nikomeh/WebSoftwareDevelopment/WEEK_4/hooks/)
+
 # React + Vite
 
 Open [WEBSITE DEMO](https://users.metropolia.fi/~nikomeh/WebSoftwareDevelopment/WEEK_4/routing/) to view it in the browser.

--- a/WEEK_4/wsk-25-react/vite.config.js
+++ b/WEEK_4/wsk-25-react/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react-swc';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/~nikomeh/WebSoftwareDevelopment/WEEK_4/routing/',
+  base: '/~nikomeh/WebSoftwareDevelopment/WEEK_4/hooks/',
 });


### PR DESCRIPTION
## Summary by Sourcery

Update README and Vite configuration to point to the hooks project website

Enhancements:
- Update base URL in Vite configuration to point to the hooks project

Documentation:
- Add website demo link to the top of the README file